### PR TITLE
update readme to use the new api format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To retrieve a token, hit the `/v1/token` endpoint with an HTTP `POST` with the f
 
 ```json
 {
-    "email": "nparsons08@gmail.com",
+    "id": "NG5y5qtDdaX9q5f",
     "name": "Nick Parsons"
 }
 ```

--- a/src/controllers/v1/token/token.action.js
+++ b/src/controllers/v1/token/token.action.js
@@ -23,9 +23,9 @@ exports.token = async (req, res) => {
 		const client = new StreamChat(apiKey, apiSecret);
 
 		const user = Object.assign({}, data, {
-			id: md5(data.email), // NOTE: It is not advised to use MD5. Please use a unique database ID for the user.
+			id: data.id, 
 			role: 'admin',
-			image: `https://robohash.org/${data.email}`,
+			image: `https://robohash.org/${data.id}`,
 		});
 		const token = client.createToken(user.id);
 		await client.updateUsers([user]);


### PR DESCRIPTION
Making a little change to the API so it uses `id` and not email as the request payload, and updating the code to use the passed in id (we no longer need to use MD5 string).